### PR TITLE
Add Claude Opus 4.5 support via Azure

### DIFF
--- a/src/llm_manager/config.yaml
+++ b/src/llm_manager/config.yaml
@@ -65,6 +65,34 @@ providers:
         reasoning_effort: true
         reasoning_summary: true
 
+      # Azure Claude Models (via Azure AI Model Inference)
+      claude-opus-4.5:
+        api_key: "${AZURE_CLAUDE_API_KEY}"
+        api_version: "${AZURE_CLAUDE_API_VERSION:-2024-12-01-preview}"
+        azure_endpoint: "${AZURE_CLAUDE_ENDPOINT}"
+        azure_deployment: "claude-opus-4-5"
+        model_id: "claude-opus-4-5-20251101"
+        model_type: "claude"
+        thinking_supported: true
+      
+      claude-sonnet-4.5:
+        api_key: "${AZURE_CLAUDE_API_KEY}"
+        api_version: "${AZURE_CLAUDE_API_VERSION:-2024-12-01-preview}"
+        azure_endpoint: "${AZURE_CLAUDE_ENDPOINT}"
+        azure_deployment: "claude-sonnet-4-5"
+        model_id: "claude-sonnet-4-5-20250514"
+        model_type: "claude"
+        thinking_supported: true
+      
+      claude-sonnet-4:
+        api_key: "${AZURE_CLAUDE_API_KEY}"
+        api_version: "${AZURE_CLAUDE_API_VERSION:-2024-12-01-preview}"
+        azure_endpoint: "${AZURE_CLAUDE_ENDPOINT}"
+        azure_deployment: "claude-sonnet-4"
+        model_id: "claude-sonnet-4-20250514"
+        model_type: "claude"
+        thinking_supported: true
+
   anthropic:
     enabled: true
     api_key: "${ANTHROPIC_API_KEY}"

--- a/src/llm_manager/providers/azure.py
+++ b/src/llm_manager/providers/azure.py
@@ -1,16 +1,23 @@
 from openai import AzureOpenAI, AsyncAzureOpenAI
 from .base import BaseProvider
 import warnings
+import json
+import httpx
 from typing import Dict, Any, Optional, Tuple
 
 class AzureProvider(BaseProvider):
-    """Provider for Azure OpenAI models"""
-    
+    """Provider for Azure OpenAI and Azure Claude models"""
+
+    # Claude models that support extended thinking
+    CLAUDE_THINKING_MODELS = ["claude-opus-4.5", "claude-opus-4", "claude-sonnet-4.5", "claude-sonnet-4", "claude-sonnet-3.7"]
+
     def __init__(self, config):
         super().__init__(config)
         self.models = config.get("models", {})
         self._clients = {}  # Cache for sync clients
         self._async_clients = {}  # Cache for async clients
+        self._http_clients = {}  # Cache for httpx clients (for Claude models)
+        self._async_http_clients = {}  # Cache for async httpx clients (for Claude models)
     
     def _create_cache_key(self, model_config: Dict[str, Any]) -> Tuple:
         """Create a cache key based on the model configuration"""
@@ -20,6 +27,28 @@ class AzureProvider(BaseProvider):
             model_config.get("azure_endpoint"),
             model_config.get("azure_deployment")
         )
+
+    def _is_claude_model(self, model_config: Dict[str, Any]) -> bool:
+        """Check if the model is a Claude model based on config"""
+        return model_config.get("model_type") == "claude"
+
+    def _get_http_client(self, model_config: Dict[str, Any]) -> httpx.Client:
+        """Get or create a synchronous httpx client for Claude models"""
+        cache_key = self._create_cache_key(model_config)
+
+        if cache_key not in self._http_clients:
+            self._http_clients[cache_key] = httpx.Client(timeout=120.0)
+
+        return self._http_clients[cache_key]
+
+    def _get_async_http_client(self, model_config: Dict[str, Any]) -> httpx.AsyncClient:
+        """Get or create an asynchronous httpx client for Claude models"""
+        cache_key = self._create_cache_key(model_config)
+
+        if cache_key not in self._async_http_clients:
+            self._async_http_clients[cache_key] = httpx.AsyncClient(timeout=120.0)
+
+        return self._async_http_clients[cache_key]
     
     def _get_client(self, model_config: Dict[str, Any]) -> AzureOpenAI:
         """Get or create a synchronous Azure client for the given model config"""
@@ -56,12 +85,21 @@ class AzureProvider(BaseProvider):
             if hasattr(client, 'close'):
                 client.close()
         self._clients.clear()
-        
+
         # Close async clients
         for client in self._async_clients.values():
             if hasattr(client, 'close'):
                 client.close()
         self._async_clients.clear()
+
+        # Close httpx clients (for Claude models)
+        for client in self._http_clients.values():
+            client.close()
+        self._http_clients.clear()
+
+        for client in self._async_http_clients.values():
+            client.close()
+        self._async_http_clients.clear()
     
     def _prepare_request_params(self, kwargs: Dict[str, Any]) -> Tuple[Dict[str, Any], str]:
         """Extract and prepare request parameters and system prompt"""
@@ -102,6 +140,142 @@ class AzureProvider(BaseProvider):
             messages.append({"role": "user", "content": prompt})
             return messages
     
+    def _generate_claude(self, prompt: str, model_id: str, model_config: Dict[str, Any], **kwargs) -> Any:
+        """Generate a response using Azure Claude API"""
+        http_client = self._get_http_client(model_config)
+        
+        endpoint = model_config.get("azure_endpoint").rstrip("/")
+        deployment = model_config.get("azure_deployment")
+        api_version = model_config.get("api_version", "2024-12-01-preview")
+        api_key = model_config.get("api_key")
+        
+        url = f"{endpoint}/openai/deployments/{deployment}/chat/completions?api-version={api_version}"
+        
+        headers = {
+            "Content-Type": "application/json",
+            "api-key": api_key
+        }
+        
+        # Build messages
+        messages = []
+        system_prompt = kwargs.pop("system", None)
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        messages.append({"role": "user", "content": prompt})
+        
+        # Build request body
+        body = {
+            "messages": messages,
+            "max_tokens": kwargs.pop("max_tokens", 4096),
+            "temperature": kwargs.pop("temperature", 0.7),
+        }
+        
+        # Handle thinking/extended thinking for Claude models
+        thinking_tokens = kwargs.pop("thinking_tokens", None)
+        supports_thinking = model_config.get("thinking_supported", False) or model_id in self.CLAUDE_THINKING_MODELS
+        
+        if thinking_tokens and supports_thinking:
+            body["temperature"] = 1.0  # Required for thinking mode
+            body["thinking"] = {
+                "type": "enabled", 
+                "budget_tokens": thinking_tokens
+            }
+            print(f"Notice: Temperature set to 1.0 for thinking mode.")
+        elif thinking_tokens and not supports_thinking:
+            print(f"Warning: 'thinking_tokens' not supported by '{model_id}'. Parameter ignored.")
+        
+        # Add any additional kwargs
+        body.update(kwargs)
+        
+        response = http_client.post(url, headers=headers, json=body)
+        response.raise_for_status()
+        
+        result = response.json()
+        
+        # Parse response - handle thinking if present
+        if "choices" in result and len(result["choices"]) > 0:
+            choice = result["choices"][0]
+            message = choice.get("message", {})
+            
+            # Check for thinking content
+            if thinking_tokens and "thinking" in message:
+                return {
+                    "thinking": message.get("thinking", ""),
+                    "response": message.get("content", "")
+                }
+            
+            return message.get("content", "")
+        
+        return result
+
+    async def _generate_claude_async(self, prompt: str, model_id: str, model_config: Dict[str, Any], **kwargs) -> Any:
+        """Generate a response asynchronously using Azure Claude API"""
+        http_client = self._get_async_http_client(model_config)
+        
+        endpoint = model_config.get("azure_endpoint").rstrip("/")
+        deployment = model_config.get("azure_deployment")
+        api_version = model_config.get("api_version", "2024-12-01-preview")
+        api_key = model_config.get("api_key")
+        
+        url = f"{endpoint}/openai/deployments/{deployment}/chat/completions?api-version={api_version}"
+        
+        headers = {
+            "Content-Type": "application/json",
+            "api-key": api_key
+        }
+        
+        # Build messages
+        messages = []
+        system_prompt = kwargs.pop("system", None)
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        messages.append({"role": "user", "content": prompt})
+        
+        # Build request body
+        body = {
+            "messages": messages,
+            "max_tokens": kwargs.pop("max_tokens", 4096),
+            "temperature": kwargs.pop("temperature", 0.7),
+        }
+        
+        # Handle thinking/extended thinking for Claude models
+        thinking_tokens = kwargs.pop("thinking_tokens", None)
+        supports_thinking = model_config.get("thinking_supported", False) or model_id in self.CLAUDE_THINKING_MODELS
+        
+        if thinking_tokens and supports_thinking:
+            body["temperature"] = 1.0  # Required for thinking mode
+            body["thinking"] = {
+                "type": "enabled",
+                "budget_tokens": thinking_tokens
+            }
+            print(f"Notice: Temperature set to 1.0 for thinking mode.")
+        elif thinking_tokens and not supports_thinking:
+            print(f"Warning: 'thinking_tokens' not supported by '{model_id}'. Parameter ignored.")
+        
+        # Add any additional kwargs
+        body.update(kwargs)
+        
+        response = await http_client.post(url, headers=headers, json=body)
+        response.raise_for_status()
+        
+        result = response.json()
+        
+        # Parse response - handle thinking if present
+        if "choices" in result and len(result["choices"]) > 0:
+            choice = result["choices"][0]
+            message = choice.get("message", {})
+            
+            # Check for thinking content
+            if thinking_tokens and "thinking" in message:
+                return {
+                    "thinking": message.get("thinking", ""),
+                    "response": message.get("content", "")
+                }
+            
+            return message.get("content", "")
+        
+        return result
+
     def generate(self, prompt: str, model_id: str, **kwargs) -> Any:
         """Generate a response using the specified Azure model"""
         if not self.is_enabled():
@@ -111,6 +285,11 @@ class AzureProvider(BaseProvider):
             raise ValueError(f"Unknown Azure model: {model_id}")
         
         model_config = self.models[model_id]
+        
+        # Route to Claude-specific handler if it's a Claude model
+        if self._is_claude_model(model_config):
+            return self._generate_claude(prompt, model_id, model_config, **kwargs)
+        
         request_kwargs, system_prompt = self._prepare_request_params(kwargs)
         supports_reasoning, supports_reasoning_summary = self._get_model_capabilities(model_config)
         client = self._get_client(model_config)
@@ -154,6 +333,11 @@ class AzureProvider(BaseProvider):
             raise ValueError(f"Unknown Azure model: {model_id}")
         
         model_config = self.models[model_id]
+        
+        # Route to Claude-specific handler if it's a Claude model
+        if self._is_claude_model(model_config):
+            return await self._generate_claude_async(prompt, model_id, model_config, **kwargs)
+        
         request_kwargs, system_prompt = self._prepare_request_params(kwargs)
         supports_reasoning, supports_reasoning_summary = self._get_model_capabilities(model_config)
         client = self._get_async_client(model_config)


### PR DESCRIPTION
## Summary
Adds support for Claude models (Opus 4.5, Sonnet 4.5, Sonnet 4) via Azure AI Model Inference API.

## Changes

### `azure.py`
- Added `_generate_claude()` and `_generate_claude_async()` methods for Azure Claude API calls
- Uses httpx for direct API calls (Azure Claude uses different auth than OpenAI)
- Supports `thinking_tokens` parameter for extended thinking mode
- Routes Claude models automatically via `model_type: 'claude'` config flag

### `config.yaml`
- Added `claude-opus-4.5`, `claude-sonnet-4.5`, `claude-sonnet-4` model configs
- New env vars: `AZURE_CLAUDE_API_KEY`, `AZURE_CLAUDE_ENDPOINT`, `AZURE_CLAUDE_API_VERSION`

## Usage
```python
from llm_manager import LLMManager

manager = LLMManager()

# Basic usage
response = manager.generate(
    prompt='Hello!',
    model='azure/claude-opus-4.5'
)

# With extended thinking
response = manager.generate(
    prompt='Solve this complex problem...',
    model='azure/claude-opus-4.5',
    thinking_tokens=10000
)
```
